### PR TITLE
Switch to unchecked vk deserialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,4 @@ Cargo.lock
 lcov.info
 
 # Outputs of generate-sample-proof binary
-proof.bin
-pubs.bin
-vk.bin
+*.bin

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ ark-bls12-381 = { version = "0.4.0", default-features = false }
 ark-ec = { version = "0.4.0", default-features = false }
 ark-serialize = { version = "0.4.0", default-features = false }
 ciborium = { version = "0.2.2", default-features = false }
+clap = { version = "4.5.20", optional = true, features = ["derive"] }
 indexmap = { version = "2.1", default-features = false, features = ["serde"] }
 proof-of-sql = { version = "0.28.6", default-features = false }
 proof-of-sql-parser = { version = "0.28.6", default-features = false }
@@ -40,7 +41,8 @@ test = [
     "proof-of-sql/test"
 ]
 rand = ["dep:rand"]
+clap = ["dep:clap"]
 
 [[bin]]
 name = "generate-sample-proof"
-required-features = ["rand", "test"]
+required-features = ["rand", "test", "clap"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -37,7 +37,7 @@ dependencies = ["run-generate-sample-proof"]
 
 [tasks.run-generate-sample-proof]
 command = "cargo"
-args = ["run", "--bin", "generate-sample-proof", "--features", "rand test"]
+args = ["run", "--bin", "generate-sample-proof", "--features", "rand test clap", "--", "--max-nu=1"]
 
 [tasks.format_inst]
 [tasks.format-inst]

--- a/src/bin/generate-sample-proof.rs
+++ b/src/bin/generate-sample-proof.rs
@@ -16,6 +16,7 @@
 use std::fs::File;
 use std::io::prelude::*;
 
+use clap::Parser;
 use proof_of_sql::base::commitment::QueryCommitments;
 use proof_of_sql::proof_primitive::dory::{
     DoryEvaluationProof, DoryProverPublicSetup, DoryVerifierPublicSetup, ProverSetup,
@@ -34,9 +35,19 @@ pub use proof_of_sql::{
 use proof_of_sql_verifier::{Proof, PublicInput, VerificationKey};
 use rand::thread_rng;
 
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+struct Args {
+    /// Value of `max_nu`
+    #[arg(long)]
+    max_nu: usize,
+}
+
 fn main() {
+    let args = Args::parse();
+
     // Initialize setup
-    let max_nu = 4;
+    let max_nu = args.max_nu;
     let sigma = max_nu;
     let public_parameters = PublicParameters::rand(max_nu, &mut thread_rng());
     let ps = ProverSetup::from(&public_parameters);
@@ -50,14 +61,22 @@ fn main() {
     accessor.add_table(
         "sxt.table".parse().unwrap(),
         owned_table([
-            bigint("a", [1, 2, 3, 2]),
-            varchar("b", ["hi", "hello", "there", "world"]),
+            bigint("a", [1, 2]),
+            varchar("b", ["hello", "bye"]),
+            varchar("c", ["foo", "bar"]),
+            varchar("d", ["dc", "marvel"]),
+            varchar("e", ["hide", "seek"]),
+            varchar("f", ["yin", "yang"]),
+            varchar("g", ["chip", "dale"]),
+            varchar("h", ["vim ", "emacs"]),
         ]),
         0,
     );
 
     let query = QueryExpr::try_new(
-        "SELECT b FROM table WHERE a = 2".parse().unwrap(),
+        "SELECT a, b, c, d, e, f, g, h FROM table WHERE a = 2"
+            .parse()
+            .unwrap(),
         "sxt".parse().unwrap(),
         &accessor,
     )
@@ -85,10 +104,10 @@ fn main() {
     let _result = proof_of_sql_verifier::verify_proof(&proof, &pubs, &vk);
 
     // Write proof, pubs, and vk to binary files
-    let mut proof_bin = File::create("proof.bin").unwrap();
+    let mut proof_bin = File::create(format!("VALID_PROOF_MAX_NU_{}.bin", max_nu)).unwrap();
     proof_bin.write_all(&proof.to_bytes()).unwrap();
-    let mut pubs_bin = File::create("pubs.bin").unwrap();
+    let mut pubs_bin = File::create(format!("VALID_PUBS_MAX_NU_{}.bin", max_nu)).unwrap();
     pubs_bin.write_all(&pubs.try_to_bytes().unwrap()).unwrap();
-    let mut vk_bin = File::create("vk.bin").unwrap();
+    let mut vk_bin = File::create(format!("VALID_VK_MAX_NU_{}.bin", max_nu)).unwrap();
     vk_bin.write_all(&vk.to_bytes()).unwrap();
 }

--- a/src/verification_key.rs
+++ b/src/verification_key.rs
@@ -96,11 +96,11 @@ impl VerificationKey {
     ///
     /// The size in bytes of the serialized VerificationKey.
     pub fn serialized_size(max_nu: usize) -> usize {
-        5 * (size_of::<usize>() + (max_nu + 1) * GT_SERIALIZED_SIZE) // Delta_1L, Delta_1R, Delta_2L, Delta_2R, chi
+        5 * (size_of::<u64>() + (max_nu + 1) * GT_SERIALIZED_SIZE) // Delta_1L, Delta_1R, Delta_2L, Delta_2R, chi
         + 2 * G1_AFFINE_SERIALIZED_SIZE// Gamma_1_0, H_1
         + 3 * G2_AFFINE_SERIALIZED_SIZE // Gamma_2_0, H_2, Gamma_2_fin
         + GT_SERIALIZED_SIZE // H_T
-        + 2 * size_of::<usize>() // max_nu, sigma
+        + 2 * size_of::<u64>() // max_nu, sigma
     }
 }
 

--- a/src/verification_key.rs
+++ b/src/verification_key.rs
@@ -48,7 +48,7 @@ impl TryFrom<&[u8]> for VerificationKey {
     ///
     /// * `Result<Self, Self::Error>` - A VerificationKey if deserialization succeeds, or a VerifyError if it fails.
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        VerificationKey::deserialize_compressed(value)
+        VerificationKey::deserialize_compressed_unchecked(value)
             .map_err(|_| VerifyError::InvalidVerificationKey)
     }
 }


### PR DESCRIPTION
Given that:
- performing the check that a point lies on the curve is very expensive to perform on-chain
- verification key contains many curve points
- verification key is public information which can (should) be independently checked off-chain

we can skip performing this check when deserializing the verification key on-chain.
This is achieved by switching from `deserialize_compressed` to `deserialize_compressed_unchecked` when deserializing the vk.

Other changes:
- fixed a bug in `VerificationKey::serialized_size()`: previous version gave correct results only on 64 bits architectures (and hence wrong results inside 32 bits Substrate wasm runtime)
- added `max-nu` parameter to `generate-sample-proof` executable